### PR TITLE
Added launch arg to enable front-facing laser.

### DIFF
--- a/jackal_gazebo/launch/jackal_world.launch
+++ b/jackal_gazebo/launch/jackal_world.launch
@@ -5,6 +5,9 @@
   <arg name="headless" default="false" />
   <arg name="world_name" default="$(find jackal_gazebo)/worlds/scenario1.world" />
 
+  <!-- Jackal accessories which may be simulated. Pass true to enable. -->
+  <arg name="front_laser" default="false" />
+
   <!-- Launch Gazebo with the empty world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="debug" value="0" />
@@ -15,7 +18,10 @@
   </include>
 
   <!-- Load Jackal's description into the Parameter Server -->
-  <include file="$(find jackal_description)/launch/description.launch" />
+  <include file="$(find jackal_description)/launch/description.launch">
+    <arg name="accessories" value="true" />
+    <arg name="front_laser" value="$(arg front_laser)" />
+  </include>
 
   <!-- Load Jackal's controllers -->
   <include file="$(find jackal_control)/launch/control.launch" />


### PR DESCRIPTION
Simulator companion to https://github.com/jackal/jackal/pull/9

Usage is:

```
roslaunch jackal_gazebo jackal_world.launch front_laser:=true
```

Concept is that there would be multiple (many?) similar options, eg back_laser, mast_laser, front_stereo_camera, front_camera, etc. We will implement and test these as the payload packages are assembled.

@Shokoofeh, @rgariepy to review.

@pmukherj, if you have a moment, I'd appreciate your thoughts too. Is this a reasonable and scalable approach? I'm assuming a really serious or highly customized user would use these building blocks to create their own description, or at least a wrapper launchfile that passes the relevant args in for them.
