### PR TITLE
Add an additional parameter to enable teleop in the simulations

### DIFF
--- a/jackal_gazebo/launch/empty_world.launch
+++ b/jackal_gazebo/launch/empty_world.launch
@@ -15,6 +15,9 @@
        See jackal_description for details. -->
   <arg name="config" default="$(arg default_config)" />
 
+  <!-- Optionally enable teleop for the simulation -->
+  <arg name="joystick" default="false" />
+
   <!-- Launch Gazebo with the specified world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="debug" value="0" />
@@ -30,5 +33,6 @@
     <arg name="y" value="0" />
     <arg name="z" value="1.0" />
     <arg name="config" value="$(arg config)" />
+    <arg name="joystick" value="$(arg joystick)" />
   </include>
 </launch>

--- a/jackal_gazebo/launch/hrtac_world.launch
+++ b/jackal_gazebo/launch/hrtac_world.launch
@@ -15,6 +15,9 @@
        See jackal_description for details. -->
   <arg name="config" default="$(arg default_config)" />
 
+  <!-- Optionally enable teleop for the simulation -->
+  <arg name="joystick" default="false" />
+
   <!-- Launch Gazebo with the specified world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="debug" value="0" />
@@ -30,5 +33,6 @@
     <arg name="y" value="0" />
     <arg name="z" value="1.0" />
     <arg name="config" value="$(arg config)" />
+    <arg name="joystick" value="$(arg joystick)" />
   </include>
 </launch>

--- a/jackal_gazebo/launch/jackal_world.launch
+++ b/jackal_gazebo/launch/jackal_world.launch
@@ -15,6 +15,9 @@
        See jackal_description for details. -->
   <arg name="config" default="$(arg default_config)" />
 
+  <!-- Optionally enable teleop for the simulation -->
+  <arg name="joystick" default="false" />
+
   <!-- Launch Gazebo with the specified world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="debug" value="0" />
@@ -30,5 +33,6 @@
     <arg name="y" value="0" />
     <arg name="z" value="1.0" />
     <arg name="config" value="$(arg config)" />
+    <arg name="joystick" value="$(arg joystick)" />
   </include>
 </launch>

--- a/jackal_gazebo/launch/spawn_jackal.launch
+++ b/jackal_gazebo/launch/spawn_jackal.launch
@@ -2,6 +2,7 @@
   <arg name="x" default="0" />
   <arg name="y" default="0" />
   <arg name="z" default="1.0" />
+  <arg name="joystick" default="false" />
 
   <!-- Configuration of Jackal which you would like to simulate.
        See jackal_description for details. -->
@@ -13,7 +14,7 @@
   </include>
   <include file="$(find jackal_control)/launch/control.launch" />
   <include file="$(find jackal_control)/launch/teleop.launch">
-    <arg name="joystick" value="false"/>
+    <arg name="joystick" value="$(arg joystick)" />
   </include>
 
   <!-- Spawn Jackal -->


### PR DESCRIPTION
Rather than launching jackal_control with joystick=false, add an additional launch parameter to enable joystick control.

e.g. roslaunch jackal_gazebo hrtac_world.launch joystick:=true